### PR TITLE
Add camera_link_frame_id for arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Refer to the [Nodes](#nodes) section to see the published topics using the messa
 
     - **`device`** device IP address (default: `192.168.1.10`)
     - **`num_worker_threads`** number of worker threads for the nodelet manager (default: `4`)
+    - **`camera_link_frame_id`** camera link frame identifier (default: `camera_link`)
     - **`color_frame_id`** color camera frame identifier (default: `camera_color_frame`)
     - **`depth_frame_id`** depth camera frame identifier (default: `camera_depth_frame`)
     - **`color_camera_info_url`** URL of color camera custom calibration file (see [camera_info_manager] documentation for calibration URL details)
@@ -107,6 +108,7 @@ Refer to the [Nodes](#nodes) section to see the published topics using the messa
 
     - **`device`** device IP address (default: `192.168.1.10`)
     - **`num_worker_threads`** number of worker threads for the nodelet manager (default: `4`)
+    - **`camera_link_frame_id`** camera link frame identifier (default: `camera_link`)
     - **`color_frame_id`** color camera frame identifier (default: `camera_color_frame`)
     - **`depth_frame_id`** depth camera frame identifier (default: `camera_depth_frame`)
     - **`color_camera_info_url`** URL of color camera custom calibration file (see [camera_info_manager] documentation for calibration URL details)
@@ -118,6 +120,7 @@ Refer to the [Nodes](#nodes) section to see the published topics using the messa
 
     - **`device`** device IP address (default: `192.168.1.10`)
     - **`num_worker_threads`** number of worker threads for the nodelet manager (default: `4`)
+    - **`camera_link_frame_id`** camera link frame identifier (default: `camera_link`)
     - **`color_frame_id`** color camera frame identifier (default: `camera_color_frame`)
     - **`color_camera_info_url`** URL of color camera custom calibration file (see [camera_info_manager] documentation for calibration URL details)
 
@@ -127,6 +130,7 @@ Refer to the [Nodes](#nodes) section to see the published topics using the messa
 
     - **`device`** device IP address (default: `192.168.1.10`)
     - **`num_worker_threads`** number of worker threads for the nodelet manager (default: `4`)
+    - **`camera_link_frame_id`** camera link frame identifier (default: `camera_link`)
     - **`depth_frame_id`** depth camera frame identifier (default: `camera_depth_frame`)
     - **`depth_camera_info_url`** URL of depth camera custom calibration file (see [camera_info_manager] documentation for calibration URL details)
 

--- a/launch/kinova_vision.launch
+++ b/launch/kinova_vision.launch
@@ -14,6 +14,9 @@
        doc="'camera' should uniquely identify the device. All topics are pushed down
             into the 'camera' namespace." />
 
+  <arg name="camera_link_frame_id" default="camera_link"
+       doc="Camera link frame identifier." />
+
   <arg name="color_frame_id" default="camera_color_frame"
        doc="Color camera frame identifier." />
 
@@ -92,12 +95,12 @@
     <node pkg="tf2_ros"
       type="static_transform_publisher"
       name="camera_depth_tf_publisher"
-      args="-0.0195 -0.005 0 0 0 0 camera_link $(arg depth_frame_id)" />
+      args="-0.0195 -0.005 0 0 0 0 $(arg camera_link_frame_id) $(arg depth_frame_id)" />
 
     <node pkg="tf2_ros"
       type="static_transform_publisher"
       name="camera_color_tf_publisher"
-      args="0 0 0 0 0 0 camera_link $(arg color_frame_id)" />
+      args="0 0 0 0 0 0 $(arg camera_link_frame_id) $(arg color_frame_id)" />
 
     <!-- Processing modules configuration-->
     <arg name="rgb_processing"                  default="true"  />

--- a/launch/kinova_vision_color_only.launch
+++ b/launch/kinova_vision_color_only.launch
@@ -14,6 +14,9 @@
        doc="'camera' should uniquely identify the device. All topics are pushed down
             into the 'camera' namespace." />
 
+  <arg name="camera_link_frame_id" default="camera_link"
+       doc="Camera link frame identifier." />
+
   <arg name="color_frame_id" default="camera_color_frame"
        doc="Color camera frame identifier." />
 
@@ -67,7 +70,7 @@
     <node pkg="tf2_ros"
       type="static_transform_publisher"
       name="camera_color_tf_publisher"
-      args="0 0 0 0 0 0 camera_link $(arg color_frame_id)" />
+      args="0 0 0 0 0 0 $(arg camera_link_frame_id) $(arg color_frame_id)" />
 
     <!-- Processing modules configuration-->
     <arg name="rgb_processing"                  default="true"  />

--- a/launch/kinova_vision_depth_only.launch
+++ b/launch/kinova_vision_depth_only.launch
@@ -14,6 +14,9 @@
        doc="'camera' should uniquely identify the device. All topics are pushed down
             into the 'camera' namespace." />
 
+  <arg name="camera_link_frame_id" default="camera_link"
+       doc="Camera link frame identifier." />
+
   <arg name="color_frame_id" default="camera_color_frame"
        doc="Color camera frame identifier." />
 
@@ -67,7 +70,7 @@
     <node pkg="tf2_ros"
       type="static_transform_publisher"
       name="camera_depth_tf_publisher"
-      args="-0.0195 -0.005 0 0 0 0 camera_link $(arg depth_frame_id)" />
+      args="-0.0195 -0.005 0 0 0 0 $(arg camera_link_frame_id) $(arg depth_frame_id)" />
 
     <!-- Processing modules configuration-->
     <arg name="rgb_processing"                  default="false"  />

--- a/launch/kinova_vision_rgbd.launch
+++ b/launch/kinova_vision_rgbd.launch
@@ -14,6 +14,9 @@
        doc="'camera' should uniquely identify the device. All topics are pushed down
             into the 'camera' namespace." />
 
+  <arg name="camera_link_frame_id" default="camera_link"
+       doc="Camera link frame identifier." />
+
   <arg name="color_frame_id" default="camera_color_frame"
        doc="Color camera frame identifier." />
 
@@ -91,12 +94,12 @@
     <node pkg="tf2_ros"
       type="static_transform_publisher"
       name="camera_depth_tf_publisher"
-      args="-0.0195 -0.005 0 0 0 0 camera_link $(arg depth_frame_id)" />
+      args="-0.0195 -0.005 0 0 0 0 $(arg camera_link_frame_id) $(arg depth_frame_id)" />
 
     <node pkg="tf2_ros"
       type="static_transform_publisher"
       name="camera_color_tf_publisher"
-      args="0 0 0 0 0 0 camera_link $(arg color_frame_id)" />
+      args="0 0 0 0 0 0 $(arg camera_link_frame_id) $(arg color_frame_id)" />
 
     <!-- Processing modules configuration-->
     <arg name="rgb_processing"                  default="true"  />


### PR DESCRIPTION
# What is this?

This PR makes it possible to change the base camera_link by adding the `camera_link_frame_id` argument to each launch file.