### PR TITLE
Increased timeout to wait longer for connectivity

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -8,7 +8,7 @@ const std::string DEFAULT_DEPTH_FRAME_ID = "camera_depth_frame";
 const std::string DEFAULT_COLOR_FRAME_ID = "camera_color_frame";
 
 const float RETRY_INTERVAL = 3.0;
-const unsigned int STATE_CHANGE_ASYNC_TIMEOUT = 5;
+const unsigned int STATE_CHANGE_ASYNC_TIMEOUT = 15;
 const unsigned int APP_SINK_BUFFER_COUNT = 5;
 
 #endif


### PR DESCRIPTION
The prior STATE_CHANGE_ASYNC_TIMEOUT was not long enough for the camera to establish a connection to the streamer. Therefore, it was increased.
Closes #6 